### PR TITLE
Create docker images on pull requests

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
             rob93c/stickerify
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
+            type=ref,prefix=pr-,event=pr
           flavor: |
             latest=auto
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,8 +24,8 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadate
-        id: meta
+      - name: Extract metadata
+        id: metadata
         uses: docker/metadata-action@v4
         with:
           images: |
@@ -41,6 +41,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.metadata.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
             rob93c/stickerify
           tags: |
             type=ref,event=branch
-            type=ref,prefix=pr-,event=pr
+            type=ref,event=pr
           flavor: |
             latest=auto
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,6 +2,7 @@ name: Docker Image CI
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
@@ -23,11 +24,23 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract metadate
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            rob93c/stickerify
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+          flavor: |
+            latest=auto
+
       - name: Upload Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: rob93c/stickerify:latest
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,10 +31,9 @@ jobs:
           images: |
             rob93c/stickerify
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=ref,event=pr
-          flavor: |
-            latest=auto
 
       - name: Upload Docker image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This ticket aims to put in place automatic builds of Docker images when a pull request is raised, automatically handling its tag:
- for pull requests, the tag will be "pr-" and pull request number
- for commits to main, `latest` will be used

The new Github Action added is [metadata-action](https://github.com/docker/metadata-action).