### PR TITLE
Fix Gradle test dependencies loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation libs.telegram.bot.api
     implementation libs.tika
 
+    testRuntimeOnly libs.junit.platform
     testImplementation libs.hamcrest
     testImplementation libs.junit
     testImplementation libs.mockwebserver

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ imageio-webp = "com.twelvemonkeys.imageio:imageio-webp:3.10.0"
 imgscalr = "org.imgscalr:imgscalr-lib:4.2"
 jave = "ws.schild:jave-core:3.3.1"
 junit = "org.junit.jupiter:junit-jupiter:5.10.0"
+junit-platform = "org.junit.platform:junit-platform-launcher:1.10.0"
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
 mockwebserver = "com.squareup.okhttp3:mockwebserver3-junit5:5.0.0-alpha.11"

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -9,7 +9,6 @@ import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDE
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FILE_SIZE;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FRAMES;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.VP9_CODEC;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.stickerifier.stickerify.process.PathLocator;
 import com.github.stickerifier.stickerify.process.ProcessHelper;
@@ -116,7 +115,7 @@ public final class MediaHelper {
 			String uncompressedContent = "";
 
 			try (var gzipInputStream = new GZIPInputStream(new FileInputStream(file))) {
-				uncompressedContent = new String(gzipInputStream.readAllBytes(), UTF_8);
+				uncompressedContent = ProcessHelper.readStream(gzipInputStream);
 			} catch (IOException e) {
 				LOGGER.atError().log("Unable to retrieve gzip content from file {}", file.getName());
 			}
@@ -135,7 +134,7 @@ public final class MediaHelper {
 
 	private record AnimationDetails(@SerializedName("w") int width, @SerializedName("h") int height, @SerializedName("fr") int frameRate, @SerializedName("ip") float start, @SerializedName("op") float end) {
 		private float duration() {
-			return (end() - start()) / frameRate();
+			return (end - start) / frameRate;
 		}
 	}
 

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -9,6 +9,7 @@ import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDE
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FILE_SIZE;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FRAMES;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.VP9_CODEC;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.stickerifier.stickerify.process.PathLocator;
 import com.github.stickerifier.stickerify.process.ProcessHelper;
@@ -31,7 +32,6 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
@@ -116,7 +116,7 @@ public final class MediaHelper {
 			String uncompressedContent = "";
 
 			try (var gzipInputStream = new GZIPInputStream(new FileInputStream(file))) {
-				uncompressedContent = new String(gzipInputStream.readAllBytes(), StandardCharsets.UTF_8);
+				uncompressedContent = new String(gzipInputStream.readAllBytes(), UTF_8);
 			} catch (IOException e) {
 				LOGGER.atError().log("Unable to retrieve gzip content from file {}", file.getName());
 			}

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -9,6 +9,7 @@ import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDE
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FILE_SIZE;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FRAMES;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.VP9_CODEC;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.stickerifier.stickerify.process.PathLocator;
 import com.github.stickerifier.stickerify.process.ProcessHelper;
@@ -115,7 +116,7 @@ public final class MediaHelper {
 			String uncompressedContent = "";
 
 			try (var gzipInputStream = new GZIPInputStream(new FileInputStream(file))) {
-				uncompressedContent = ProcessHelper.readStream(gzipInputStream);
+				uncompressedContent = new String(gzipInputStream.readAllBytes(), UTF_8);
 			} catch (IOException e) {
 				LOGGER.atError().log("Unable to retrieve gzip content from file {}", file.getName());
 			}

--- a/src/main/java/com/github/stickerifier/stickerify/process/PathLocator.java
+++ b/src/main/java/com/github/stickerifier/stickerify/process/PathLocator.java
@@ -1,6 +1,7 @@
 package com.github.stickerifier.stickerify.process;
 
 import static com.github.stickerifier.stickerify.process.ProcessHelper.IS_WINDOWS;
+import static java.lang.System.lineSeparator;
 
 import com.github.stickerifier.stickerify.telegram.exception.TelegramApiException;
 import org.slf4j.Logger;
@@ -23,7 +24,7 @@ public class PathLocator implements ProcessLocator {
 	public PathLocator() {
 		try {
 			if (ffmpegLocation == null || ffmpegLocation.isBlank()) {
-				ffmpegLocation = ProcessHelper.executeCommand(FIND_FFMPEG).split(System.lineSeparator())[0];
+				ffmpegLocation = ProcessHelper.executeCommand(FIND_FFMPEG).split(lineSeparator())[0];
 			}
 
 			LOGGER.atInfo().log("FFmpeg is installed at {}", ffmpegLocation);

--- a/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
@@ -61,7 +61,7 @@ public final class ProcessHelper {
 	 * @return the UTF-8 representation of passed-in stream
 	 * @throws IOException if an error occurs reading stream's bytes
 	 */
-	public static String readStream(InputStream stream) throws IOException {
+	private static String readStream(InputStream stream) throws IOException {
 		return new String(stream.readAllBytes(), UTF_8);
 	}
 

--- a/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
@@ -54,7 +54,14 @@ public final class ProcessHelper {
 		}
 	}
 
-	private static String readStream(InputStream stream) throws IOException {
+	/**
+	 * Processes the content of the stream and retrieves its UTF-8 string representation.
+	 *
+	 * @param stream the stream to be decoded
+	 * @return the UTF-8 representation of passed-in stream
+	 * @throws IOException if an error occurs reading stream's bytes
+	 */
+	public static String readStream(InputStream stream) throws IOException {
 		return new String(stream.readAllBytes(), UTF_8);
 	}
 

--- a/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
@@ -39,11 +39,11 @@ public final class ProcessHelper {
 
 			if (!processExited || process.exitValue() != 0) {
 				var reason = processExited ? "successfully" : "in time";
-				var output = toString(process.getErrorStream());
+				var output = readStream(process.getErrorStream());
 				throw new TelegramApiException("The command {} couldn't complete {}: {}", command[0], reason, output);
 			}
 
-			return toString(process.getInputStream());
+			return readStream(process.getInputStream());
 		} catch (IOException | InterruptedException e) {
 			throw new TelegramApiException(e);
 		} finally {
@@ -54,7 +54,7 @@ public final class ProcessHelper {
 		}
 	}
 
-	private static String toString(InputStream stream) throws IOException {
+	private static String readStream(InputStream stream) throws IOException {
 		return new String(stream.readAllBytes(), UTF_8);
 	}
 

--- a/src/test/java/com/github/stickerifier/stickerify/ResourceHelper.java
+++ b/src/test/java/com/github/stickerifier/stickerify/ResourceHelper.java
@@ -37,5 +37,4 @@ public final class ResourceHelper {
 
 		return new File(resource.getFile());
 	}
-
 }

--- a/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
@@ -1,12 +1,13 @@
 package com.github.stickerifier.stickerify.bot;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.stickerifier.stickerify.ResourceHelper;
-import com.github.stickerifier.stickerify.telegram.Answer;
 import com.github.stickerifier.stickerify.junit.ClearTempFiles;
+import com.github.stickerifier.stickerify.telegram.Answer;
 import com.pengrad.telegrambot.TelegramBot;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 @ClearTempFiles
 @ExtendWith(MockWebServerExtension.class)
@@ -62,7 +62,7 @@ class StickerifyTest {
 	}
 
 	private static void assertResponseContainsMessage(RecordedRequest request, Answer answer) {
-		var message = URLEncoder.encode(answer.getText(), StandardCharsets.UTF_8);
+		var message = URLEncoder.encode(answer.getText(), UTF_8);
 		assertThat(request.getBody().readUtf8(), containsString(message));
 	}
 
@@ -268,5 +268,4 @@ class StickerifyTest {
 		assertEquals("/api/token/sendMessage", sendMessage.getPath());
 		assertResponseContainsMessage(sendMessage, Answer.ERROR);
 	}
-
 }

--- a/src/test/java/com/github/stickerifier/stickerify/junit/TempFilesCleanupExtension.java
+++ b/src/test/java/com/github/stickerifier/stickerify/junit/TempFilesCleanupExtension.java
@@ -22,21 +22,21 @@ public class TempFilesCleanupExtension implements AfterAllCallback {
 		deleteTempFiles();
 	}
 
-	private static void deleteTempFiles() throws IOException {
-		try (var files = Files.list(Path.of(System.getProperty("java.io.tmpdir")))) {
-			files.filter(Files::isRegularFile)
-					.filter(TempFilesCleanupExtension::stickerifyFiles)
-					.forEach(TempFilesCleanupExtension::deleteFile);
+	private void deleteTempFiles() throws IOException {
+		var tempFolder = System.getProperty("java.io.tmpdir");
+
+		try (var files = Files.list(Path.of(tempFolder))) {
+			files.filter(this::stickerifyFiles).forEach(this::deleteFile);
 		}
 	}
 
-	private static boolean stickerifyFiles(Path path) {
+	private boolean stickerifyFiles(Path path) {
 		var fileName = path.getFileName().toString();
 
-		return fileName.startsWith("Stickerify-") || fileName.startsWith("OriginalFile-");
+		return Files.isRegularFile(path) && (fileName.startsWith("Stickerify-") || fileName.startsWith("OriginalFile-"));
 	}
 
-	private static void deleteFile(Path path) {
+	private void deleteFile(Path path) {
 		try {
 			Files.delete(path);
 

--- a/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
@@ -48,8 +48,8 @@ class MediaHelperTest {
 
 	@Test
 	void resizeImage() throws Exception {
-		var startingImage = resources.createImage(1024, 1024, "jpg");
-		var result = MediaHelper.convert(startingImage);
+		var jpgImage = resources.createImage(1024, 1024, "jpg");
+		var result = MediaHelper.convert(jpgImage);
 
 		assertImageConsistency(result, 512, 512);
 	}
@@ -67,40 +67,40 @@ class MediaHelperTest {
 
 	@Test
 	void resizeRectangularImage() throws Exception {
-		var startingImage = resources.createImage(1024, 512, "jpg");
-		var result = MediaHelper.convert(startingImage);
+		var jpgImage = resources.createImage(1024, 512, "jpg");
+		var result = MediaHelper.convert(jpgImage);
 
 		assertImageConsistency(result, 512, 256);
 	}
 
 	@Test
 	void resizeSmallImage() throws Exception {
-		var startingImage = resources.createImage(256, 256, "png");
-		var result = MediaHelper.convert(startingImage);
+		var pngImage = resources.createImage(256, 256, "png");
+		var result = MediaHelper.convert(pngImage);
 
 		assertImageConsistency(result, 512, 512);
 	}
 
 	@Test
 	void noImageConversionNeeded() throws Exception {
-		var startingImage = resources.createImage(512, 256, "png");
-		var result = MediaHelper.convert(startingImage);
+		var pngImage = resources.createImage(512, 256, "png");
+		var result = MediaHelper.convert(pngImage);
 
 		assertThat(result, is(nullValue()));
 	}
 
 	@Test
 	void resizeWebpImage() throws Exception {
-		var startingImage = resources.loadResource("valid.webp");
-		var result = MediaHelper.convert(startingImage);
+		var webpImage = resources.loadResource("valid.webp");
+		var result = MediaHelper.convert(webpImage);
 
 		assertImageConsistency(result, 256, 512);
 	}
 
 	@Test
 	void convertLongMovVideo() throws Exception {
-		var startingVideo = resources.loadResource("long.mov");
-		var result = MediaHelper.convert(startingVideo);
+		var movVideo = resources.loadResource("long.mov");
+		var result = MediaHelper.convert(movVideo);
 
 		assertVideoConsistency(result, 512, 288, 29.97F, 3_000L);
 	}
@@ -127,48 +127,48 @@ class MediaHelperTest {
 
 	@Test
 	void convertMp4WithAudio() throws Exception {
-		var startingVideo = resources.loadResource("video_with_audio.mp4");
-		var result = MediaHelper.convert(startingVideo);
+		var mp4Video = resources.loadResource("video_with_audio.mp4");
+		var result = MediaHelper.convert(mp4Video);
 
 		assertVideoConsistency(result, 512, 288, 29.97F, 3_000L);
 	}
 
 	@Test
 	void convertShortAndLowFpsVideo() throws Exception {
-		var startingVideo = resources.loadResource("short_low_fps.webm");
-		var result = MediaHelper.convert(startingVideo);
+		var webmVideo = resources.loadResource("short_low_fps.webm");
+		var result = MediaHelper.convert(webmVideo);
 
 		assertVideoConsistency(result, 512, 288, 10F, 1_000L);
 	}
 
 	@Test
 	void resizeSmallWebmVideo() throws Exception {
-		var startingVideo = resources.loadResource("small_video_sticker.webm");
-		var result = MediaHelper.convert(startingVideo);
+		var webmVideo = resources.loadResource("small_video_sticker.webm");
+		var result = MediaHelper.convert(webmVideo);
 
 		assertVideoConsistency(result, 512, 212, 30F, 2_000L);
 	}
 
 	@Test
 	void convertVerticalWebmVideo() throws Exception {
-		var startingVideo = resources.loadResource("vertical_video_sticker.webm");
-		var result = MediaHelper.convert(startingVideo);
+		var webmVideo = resources.loadResource("vertical_video_sticker.webm");
+		var result = MediaHelper.convert(webmVideo);
 
 		assertVideoConsistency(result, 288, 512, 30F, 2_000L);
 	}
 
 	@Test
 	void convertGifVideo() throws Exception {
-		var startingVideo = resources.loadResource("valid.gif");
-		var result = MediaHelper.convert(startingVideo);
+		var gifVideo = resources.loadResource("valid.gif");
+		var result = MediaHelper.convert(gifVideo);
 
 		assertVideoConsistency(result, 512, 274, 10F, 1_000L);
 	}
 
 	@Test
 	void noVideoConversionNeeded() throws Exception {
-		var startingVideo = resources.loadResource("no_conversion_needed.webm");
-		var result = MediaHelper.convert(startingVideo);
+		var webmVideo = resources.loadResource("no_conversion_needed.webm");
+		var result = MediaHelper.convert(webmVideo);
 
 		assertThat(result, is(nullValue()));
 	}

--- a/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
@@ -211,12 +211,12 @@ class MediaHelperTest {
 		@Test
 		@DisplayName("mov videos")
 		void concurrentMovVideoConversions() {
-			var startingVideo = resources.loadResource("long.mov");
+			var movVideo = resources.loadResource("long.mov");
 
-			executeConcurrentConversions(startingVideo);
+			executeConcurrentConversionsOf(movVideo);
 		}
 
-		private static void executeConcurrentConversions(File inputFile) {
+		private static void executeConcurrentConversionsOf(File inputFile) {
 			final int concurrentRequests = 50;
 			var failedConversions = new AtomicInteger(0);
 
@@ -239,41 +239,41 @@ class MediaHelperTest {
 		@Test
 		@DisplayName("mp4 videos")
 		void concurrentMp4VideoConversions() {
-			var startingVideo = resources.loadResource("video_with_audio.mp4");
+			var mp4Video = resources.loadResource("video_with_audio.mp4");
 
-			executeConcurrentConversions(startingVideo);
+			executeConcurrentConversionsOf(mp4Video);
 		}
 
 		@Test
 		@DisplayName("webm videos")
 		void concurrentWebmVideoConversions() {
-			var startingVideo = resources.loadResource("small_video_sticker.webm");
+			var webmVideo = resources.loadResource("small_video_sticker.webm");
 
-			executeConcurrentConversions(startingVideo);
+			executeConcurrentConversionsOf(webmVideo);
 		}
 
 		@Test
 		@DisplayName("gif videos")
 		void concurrentGifVideoConversions() {
-			var startingVideo = resources.loadResource("valid.gif");
+			var gifVideo = resources.loadResource("valid.gif");
 
-			executeConcurrentConversions(startingVideo);
+			executeConcurrentConversionsOf(gifVideo);
 		}
 
 		@Test
 		@DisplayName("webp images")
 		void concurrentWebpImageConversions() {
-			var startingImage = resources.loadResource("valid.webp");
+			var webpImage = resources.loadResource("valid.webp");
 
-			executeConcurrentConversions(startingImage);
+			executeConcurrentConversionsOf(webpImage);
 		}
 
 		@Test
 		@DisplayName("png images")
 		void concurrentPngImageConversions() {
-			var startingImage = resources.createImage(256, 256, "png");
+			var pngImage = resources.createImage(256, 256, "png");
 
-			executeConcurrentConversions(startingImage);
+			executeConcurrentConversionsOf(pngImage);
 		}
 	}
 }


### PR DESCRIPTION
This pull request aims to fix the following warning Gradle shows when launching unit tests:

> The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

In addition to this, the code has been cleaned up in some classes. 
