### PR TITLE
Print video information with `ffprobe` when video analysis fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ FROM gcr.io/distroless/base-nossl AS bot
 COPY --from=builder /app/build/jre ./jre
 COPY --from=builder /app/build/libs/Stickerify-shadow.jar .
 COPY --from=mwader/static-ffmpeg /ffmpeg /usr/local/bin/
+COPY --from=mwader/static-ffmpeg /ffprobe /usr/local/bin/
 ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
 CMD ["jre/bin/java", "-jar", "Stickerify-shadow.jar"]

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -318,8 +318,29 @@ public final class MediaHelper {
 		try {
 			return new MultimediaObject(file, FFMPEG_LOCATOR).getInfo();
 		} catch (EncoderException e) {
+			logVideoInformation(file);
 			throw new TelegramApiException(e);
 		}
+	}
+
+	/**
+	 * Logs the multimedia information of passed-in video file.
+	 *
+	 * @param file the video to retrieve information from
+	 * @throws TelegramApiException if an error occurred processing the video
+	 */
+	private static void logVideoInformation(File file) throws TelegramApiException {
+		var ffprobeCommand = new String[] {
+				"ffprobe",
+				"-v", "quiet",
+				"-show_format",
+				"-show_streams",
+				file.getAbsolutePath()
+		};
+
+		var videoInformation = ProcessHelper.executeCommand(ffprobeCommand);
+
+		LOGGER.atWarn().log("The video could not be processed successfully\n{}", videoInformation);
 	}
 
 	/**

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -316,6 +316,7 @@ public final class MediaHelper {
 	 */
 	private static MultimediaInfo retrieveMultimediaInfo(File file) throws TelegramApiException {
 		try {
+			logVideoInformation(file);
 			return new MultimediaObject(file, FFMPEG_LOCATOR).getInfo();
 		} catch (EncoderException e) {
 			logVideoInformation(file);

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -316,7 +316,6 @@ public final class MediaHelper {
 	 */
 	private static MultimediaInfo retrieveMultimediaInfo(File file) throws TelegramApiException {
 		try {
-			logVideoInformation(file);
 			return new MultimediaObject(file, FFMPEG_LOCATOR).getInfo();
 		} catch (EncoderException e) {
 			logVideoInformation(file);

--- a/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/process/ProcessHelper.java
@@ -43,7 +43,7 @@ public final class ProcessHelper {
 				throw new TelegramApiException("The command {} couldn't complete {}: {}", command[0], reason, output);
 			}
 
-			return readStream(process.getInputStream());
+			return readProcessOutput(process);
 		} catch (IOException | InterruptedException e) {
 			throw new TelegramApiException(e);
 		} finally {
@@ -63,6 +63,21 @@ public final class ProcessHelper {
 	 */
 	private static String readStream(InputStream stream) throws IOException {
 		return new String(stream.readAllBytes(), UTF_8);
+	}
+
+	/**
+	 * Reads the content of the input stream of the process.
+	 * If the input stream is empty, the content of the error stream is returned.
+	 *
+	 * @param process the process
+	 * @return the output of the process
+	 * @throws IOException if an error occurs reading stream's bytes
+	 */
+	private static String readProcessOutput(Process process) throws IOException {
+		var inputStream = readStream(process.getInputStream());
+		var output = inputStream.isEmpty() ? readStream(process.getErrorStream()) : inputStream;
+
+		return output.trim();
 	}
 
 	private ProcessHelper() {


### PR DESCRIPTION
Fixes #183 