### PR TITLE
Configure wait time before automatically merging dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,21 +1,40 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "packageRules": [
-    {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true,
-      "labels": [
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "labels": [
         "dependencies"
-      ]
-    }
-  ],
-  "extends": [
-    "config:base"
-  ]
+    ],
+    "assignees": [
+        "rob93c"
+    ],
+    "packageRules": [
+        {
+            "matchPackagePatterns": [
+                "*"
+            ],
+            "enabledManagers": [
+                "gradle",
+                "dockerfile",
+                "github-actions"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ],
+            "automerge": true,
+            "assignAutomerge": true,
+            "minimumReleaseAge": "1 week"
+        },
+        {
+            "matchManagers": [
+                "gradle-wrapper"
+            ],
+            "schedule": [
+                "at any time"
+            ],
+            "automerge": false
+        }
+    ],
+    "extends": [
+        "config:base"
+    ]
 }


### PR DESCRIPTION
The configuration now disables automerge for Gradle updates as they should always be manual.
Standard updates (non major) will be automerged after a week.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dependency management with new configuration options for the Renovate bot.
	- Introduced automatic assignment for merge tasks and a minimum release age for updates.
	- Expanded package rules to specify applicable package managers and update conditions.
  
- **Improvements**
	- Improved tracking and accountability by assigning specific tasks to team members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->