### PR TITLE
Added automatic version updates with bump

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,5 @@ LICENSE
 Dockerfile
 *.dockerfile
 qodana.baseline.json
+Bumpfile
+hashupdate

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,12 +1,13 @@
-name: Automatic version updates
+name: Bump CI
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 9 * * *'
-  workflow_dispatch:
 
 jobs:
   bump:
+    name: Search for dependency updates
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code changes

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -3,7 +3,7 @@ name: Bump CI
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '0 10 * * *'
 
 jobs:
   bump:

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,18 @@
+name: Automatic version updates
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code changes
+        uses: actions/checkout@v4
+
+      - name: Update dependencies
+        uses: wader/bump/action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v3
         with:
-          # bump: ffmpeg /ffmpeg-version: '([\d.]+)'/ docker:mwader/static-ffmpeg|^7.0
+          # bump: ffmpeg-ci /ffmpeg-version: '([\d.]+)'/ docker:mwader/static-ffmpeg|~7.0
           ffmpeg-version: '7.0.2'
 
       - name: Setup project and upload dependency graph

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v3
         with:
+          # bump: ffmpeg /ffmpeg-version: '([\d.]+)'/ docker:mwader/static-ffmpeg|^7.0
           ffmpeg-version: '7.0.2'
 
       - name: Setup project and upload dependency graph

--- a/Bumpfile
+++ b/Bumpfile
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Bumpfile
+++ b/Bumpfile
@@ -1,1 +1,2 @@
+.github/workflows/unit-test.yml
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN ./gradlew runtime --no-daemon
 
 FROM gcr.io/distroless/base-nossl:nonroot AS bot
 
-# bump: ffmpeg /static-ffmpeg:([\d.]+)/ docker:mwader/static-ffmpeg|^7.0
+# bump: ffmpeg /static-ffmpeg:([\d.]+)/ docker:mwader/static-ffmpeg|~7.0
 COPY --from=mwader/static-ffmpeg:7.0.2 /ffmpeg /usr/local/bin/
 ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM eclipse-temurin AS builder
 
 # bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ git:https://chromium.googlesource.com/webm/libwebp.git|*
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
-# bump: libwebp link "NEWS" https://github.com/webmproject/libwebp/blob/$LATEST/NEWS
 ARG LIBWEBP_VERSION=1.4.0
 ARG LIBWEBP_URL="https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$LIBWEBP_VERSION-linux-x86-64.tar.gz"
 ARG LIBWEBP_SHA256=94ac053be5f8cb47a493d7a56b2b1b7328bab9cff24ecb89fa642284330d8dff
@@ -19,10 +18,14 @@ COPY . .
 RUN ./gradlew runtime --no-daemon
 
 FROM gcr.io/distroless/base-nossl:nonroot AS bot
+
+# bump: ffmpeg /static-ffmpeg:([\d.]+)/ docker:mwader/static-ffmpeg|^7.0
+COPY --from=mwader/static-ffmpeg:7.0.2 /ffmpeg /usr/local/bin/
+ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
+
 COPY --from=builder /app/build/jre ./jre
 COPY --from=builder /app/build/libs/Stickerify-shadow.jar .
 COPY --from=builder /app/libwebp/bin/cwebp /usr/local/bin/
 COPY --from=builder /app/libwebp/bin/dwebp /usr/local/bin/
-COPY --from=mwader/static-ffmpeg:7.0.2 /ffmpeg /usr/local/bin/
-ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
+
 CMD ["jre/bin/java", "-Dcom.sksamuel.scrimage.webp.binary.dir=/usr/local/bin/", "-jar", "Stickerify-shadow.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 FROM eclipse-temurin AS builder
-ARG LIBWEBP=libwebp-1.4.0-linux-x86-64
-RUN curl -s -L https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP}.tar.gz | \
-    tar -xvzf - -C /tmp --one-top-level=libwebp --strip-components=1
+
+# bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ git:https://chromium.googlesource.com/webm/libwebp.git|*
+# bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
+# bump: libwebp link "NEWS" https://github.com/webmproject/libwebp/blob/$LATEST/NEWS
+ARG LIBWEBP_VERSION=1.4.0
+ARG LIBWEBP_URL="https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$LIBWEBP_VERSION-linux-x86-64.tar.gz"
+ARG LIBWEBP_SHA256=94ac053be5f8cb47a493d7a56b2b1b7328bab9cff24ecb89fa642284330d8dff
+
 WORKDIR /app
+RUN curl "$LIBWEBP_URL" -o libwebp.tar.gz
+RUN echo "$LIBWEBP_SHA256  libwebp.tar.gz" | sha256sum -c -
+RUN tar -xzf libwebp.tar.gz --one-top-level=libwebp --strip-components=1
 COPY settings.gradle build.gradle gradlew ./
 COPY gradle ./gradle
 RUN --mount=type=cache,target=/home/gradle/.gradle/caches \
@@ -13,8 +21,8 @@ RUN ./gradlew runtime --no-daemon
 FROM gcr.io/distroless/base-nossl:nonroot AS bot
 COPY --from=builder /app/build/jre ./jre
 COPY --from=builder /app/build/libs/Stickerify-shadow.jar .
-COPY --from=builder /tmp/libwebp/bin/cwebp /usr/local/bin/
-COPY --from=builder /tmp/libwebp/bin/dwebp /usr/local/bin/
+COPY --from=builder /app/libwebp/bin/cwebp /usr/local/bin/
+COPY --from=builder /app/libwebp/bin/dwebp /usr/local/bin/
 COPY --from=mwader/static-ffmpeg:7.0.2 /ffmpeg /usr/local/bin/
 ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
 CMD ["jre/bin/java", "-Dcom.sksamuel.scrimage.webp.binary.dir=/usr/local/bin/", "-jar", "Stickerify-shadow.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ ARG LIBWEBP_URL="https://storage.googleapis.com/downloads.webmproject.org/releas
 ARG LIBWEBP_SHA256=94ac053be5f8cb47a493d7a56b2b1b7328bab9cff24ecb89fa642284330d8dff
 
 WORKDIR /app
-RUN curl "$LIBWEBP_URL" -o libwebp.tar.gz
-RUN echo "$LIBWEBP_SHA256  libwebp.tar.gz" | sha256sum -c -
-RUN tar -xzf libwebp.tar.gz --one-top-level=libwebp --strip-components=1
+RUN curl "$LIBWEBP_URL" -o libwebp.tar.gz && \
+    echo "$LIBWEBP_SHA256  libwebp.tar.gz" | sha256sum -c - && \
+    tar -xzf libwebp.tar.gz --one-top-level=libwebp --strip-components=1
 COPY settings.gradle build.gradle gradlew ./
 COPY gradle ./gradle
 RUN --mount=type=cache,target=/home/gradle/.gradle/caches \

--- a/hashupdate
+++ b/hashupdate
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+# from https://github.com/wader/static-ffmpeg/blob/787709ac341e7ef16f8a1768ed1e5a30b492a0b7/hashupdate
+# Usage: hashupdate <FILE> <NAME> <VERSION>
+URL_TEMPLATE=$(grep "$2_URL=" "$1" | sed -E 's/.*="(.*)"/\1/' | tr -d '\r')
+URL=$(echo "$URL_TEMPLATE" | sed "s/\$$2_VERSION/$3/g")
+SHA256=$(curl -sL "$URL" | sha256sum | sed -e 's/  -//g')
+sed -i -E "s/$2_SHA256=.*/$2_SHA256=$SHA256/" "$1"


### PR DESCRIPTION
A new secret `BUMP_TOKEN` must be created to run workflows on the PRs openend by bump. See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow

Closes #270 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow for updating dependencies, scheduled to run daily.
	- Added a new shell script for updating SHA256 hashes based on URL templates.

- **Improvements**
	- Enhanced Dockerfile for better handling of the `libwebp` library with versioning and checksum verification.
	- Updated unit test workflow to specify a new version of FFmpeg.
	- Added entries to `.dockerignore` to exclude specific files during the Docker build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->