### PR TITLE
Configure bump to detect only minor libwebp updates

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -3,7 +3,7 @@ name: Bump CI
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: '0 8 * * *'
 
 jobs:
   bump:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin AS builder
 
-# bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ git:https://chromium.googlesource.com/webm/libwebp.git|*
+# bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ git:https://chromium.googlesource.com/webm/libwebp.git|^1
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
 ARG LIBWEBP_VERSION=1.4.0
 ARG LIBWEBP_URL="https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$LIBWEBP_VERSION-linux-x86-64.tar.gz"


### PR DESCRIPTION
Also, the schedule for the daily bump check has been moved to 8 AM UTC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the scheduled time for a cron job to trigger at 8 AM UTC daily.
	- Tightened version control for dependencies to enhance build reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->