### PR TITLE
Use latest FFmpeg version available

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+        uses: AnimMouse/setup-ffmpeg@v1
         with:
           # bump: ffmpeg-ci /ffmpeg-version: '([\d.]+)'/ docker:mwader/static-ffmpeg|~7
-          ffmpeg-version: '7.1'
+          version: master
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v3
         with:
-          # bump: ffmpeg-ci /ffmpeg-version: '([\d.]+)'/ docker:mwader/static-ffmpeg|~7.0
-          ffmpeg-version: '7.0.2'
+          # bump: ffmpeg-ci /ffmpeg-version: '([\d.]+)'/ docker:mwader/static-ffmpeg|~7
+          ffmpeg-version: '7.1'
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Setup FFmpeg
         uses: AnimMouse/setup-ffmpeg@v1
         with:
-          # bump: ffmpeg-ci /ffmpeg-version: '([\d.]+)'/ docker:mwader/static-ffmpeg|~7
           version: master
 
       - name: Setup Java

--- a/Bumpfile
+++ b/Bumpfile
@@ -1,3 +1,2 @@
-.github/workflows/unit-test.yml
 Dockerfile
 qodana.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN ./gradlew runtime --no-daemon
 
 FROM gcr.io/distroless/base-nossl:nonroot AS bot
 
-# bump: ffmpeg /static-ffmpeg:([\d.]+)/ docker:mwader/static-ffmpeg|~7
-COPY --from=mwader/static-ffmpeg:7.1 /ffmpeg /usr/local/bin/
+COPY --from=mwader/static-ffmpeg:latest /ffmpeg /usr/local/bin/
 ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
 
 COPY --from=builder /app/build/jre ./jre

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN ./gradlew runtime --no-daemon
 
 FROM gcr.io/distroless/base-nossl:nonroot AS bot
 
-# bump: ffmpeg /static-ffmpeg:([\d.]+)/ docker:mwader/static-ffmpeg|~7.0
-COPY --from=mwader/static-ffmpeg:7.0.2 /ffmpeg /usr/local/bin/
+# bump: ffmpeg /static-ffmpeg:([\d.]+)/ docker:mwader/static-ffmpeg|~7
+COPY --from=mwader/static-ffmpeg:7.1 /ffmpeg /usr/local/bin/
 ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
 
 COPY --from=builder /app/build/jre ./jre

--- a/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
@@ -188,7 +188,7 @@ class MediaHelperTest {
 		var webmVideo = loadResource("short_low_fps.webm");
 		var result = MediaHelper.convert(webmVideo);
 
-		assertVideoConsistency(result, 512, 288, 10F, 900L);
+		assertVideoConsistency(result, 512, 288, 10F, 1_000L);
 	}
 
 	@Test
@@ -204,7 +204,7 @@ class MediaHelperTest {
 		var webmVideo = loadResource("vertical_video_sticker.webm");
 		var result = MediaHelper.convert(webmVideo);
 
-		assertVideoConsistency(result, 288, 512, 30F, 1_970L);
+		assertVideoConsistency(result, 288, 512, 30F, 2_000L);
 	}
 
 	@Test
@@ -212,7 +212,7 @@ class MediaHelperTest {
 		var gifVideo = loadResource("valid.gif");
 		var result = MediaHelper.convert(gifVideo);
 
-		assertVideoConsistency(result, 512, 274, 10F, 900L);
+		assertVideoConsistency(result, 512, 274, 10F, 1_000L);
 	}
 
 	@Test
@@ -220,7 +220,7 @@ class MediaHelperTest {
 		var aviVideo = loadResource("valid.avi");
 		var result = MediaHelper.convert(aviVideo);
 
-		assertVideoConsistency(result, 512, 512, 30F, 2_970L);
+		assertVideoConsistency(result, 512, 512, 30F, 3_000L);
 	}
 
 	@Test

--- a/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
@@ -188,7 +188,7 @@ class MediaHelperTest {
 		var webmVideo = loadResource("short_low_fps.webm");
 		var result = MediaHelper.convert(webmVideo);
 
-		assertVideoConsistency(result, 512, 288, 10F, 1_000L);
+		assertVideoConsistency(result, 512, 288, 10F, 900L);
 	}
 
 	@Test
@@ -204,7 +204,7 @@ class MediaHelperTest {
 		var webmVideo = loadResource("vertical_video_sticker.webm");
 		var result = MediaHelper.convert(webmVideo);
 
-		assertVideoConsistency(result, 288, 512, 30F, 2_000L);
+		assertVideoConsistency(result, 288, 512, 30F, 1_970L);
 	}
 
 	@Test
@@ -212,7 +212,7 @@ class MediaHelperTest {
 		var gifVideo = loadResource("valid.gif");
 		var result = MediaHelper.convert(gifVideo);
 
-		assertVideoConsistency(result, 512, 274, 10F, 1_000L);
+		assertVideoConsistency(result, 512, 274, 10F, 900L);
 	}
 
 	@Test
@@ -220,7 +220,7 @@ class MediaHelperTest {
 		var aviVideo = loadResource("valid.avi");
 		var result = MediaHelper.convert(aviVideo);
 
-		assertVideoConsistency(result, 512, 512, 30F, 3_000L);
+		assertVideoConsistency(result, 512, 512, 30F, 2_970L);
 	}
 
 	@Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow for unit tests to use a different action for FFmpeg setup and switched to the latest version.
	- Removed the unit test workflow configuration, Dockerfile, and Qodana configuration files.
	- Adjusted the Dockerfile to retrieve the latest FFmpeg version instead of a fixed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->