### PR TITLE
Run tests with custom JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN curl -L --fail --retry 3 --retry-delay 5 "$LIBWEBP_URL" -o libwebp.tar.gz &&
     tar -xzf libwebp.tar.gz --one-top-level=libwebp --strip-components=1
 COPY settings.gradle build.gradle gradlew ./
 COPY gradle ./gradle
-RUN --mount=type=cache,target=/home/gradle/.gradle/caches \
-    ./gradlew dependencies --no-daemon
+RUN --mount=type=cache,target=/home/gradle/.gradle/caches ./gradlew dependencies --no-daemon
 COPY . .
 RUN ./gradlew runtime --no-daemon
 
@@ -25,9 +24,8 @@ ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
 
 COPY --from=builder /app/libwebp/bin/cwebp /usr/local/bin/
 COPY --from=builder /app/libwebp/bin/dwebp /usr/local/bin/
-COPY --from=builder /app/libwebp/bin/gif2webp /usr/local/bin/
 
 COPY --from=builder /app/build/jre jre
-COPY --from=builder /app/build/libs/Stickerify-*-all.jar Stickerify.jar
+COPY --from=builder /app/build/libs/Stickerify-1.0-all.jar Stickerify.jar
 
 CMD ["jre/bin/java", "-XX:+UseZGC", "-Dcom.sksamuel.scrimage.webp.binary.dir=/usr/local/bin/", "-jar", "Stickerify.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,11 @@ FROM gcr.io/distroless/base-nossl:nonroot AS bot
 COPY --from=mwader/static-ffmpeg:7.0.2 /ffmpeg /usr/local/bin/
 ENV FFMPEG_PATH=/usr/local/bin/ffmpeg
 
-COPY --from=builder /app/build/jre ./jre
-COPY --from=builder /app/build/libs/Stickerify-shadow.jar .
 COPY --from=builder /app/libwebp/bin/cwebp /usr/local/bin/
 COPY --from=builder /app/libwebp/bin/dwebp /usr/local/bin/
+COPY --from=builder /app/libwebp/bin/gif2webp /usr/local/bin/
 
-CMD ["jre/bin/java", "-XX:+UseZGC", "-Dcom.sksamuel.scrimage.webp.binary.dir=/usr/local/bin/", "-jar", "Stickerify-shadow.jar"]
+COPY --from=builder /app/build/jre jre
+COPY --from=builder /app/build/libs/Stickerify-*-all.jar Stickerify.jar
+
+CMD ["jre/bin/java", "-XX:+UseZGC", "-Dcom.sksamuel.scrimage.webp.binary.dir=/usr/local/bin/", "-jar", "Stickerify.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,31 @@ dependencies {
     }
 }
 
+group = 'com.github.stickerifier'
+version = '1.0'
+description = 'Telegram bot to convert medias in the format required to be used as Telegram stickers'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(23)
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    dependsOn jre
+    inputs.files jre.outputs.files
+
+    def file = DefaultNativePlatform.currentOperatingSystem.isWindows() ? 'java.exe' : 'java'
+    executable = layout.buildDirectory.file('jre/bin/' + file).get()
+
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
 jacocoTestReport {
     reports {
         html.required = false
@@ -56,45 +81,21 @@ jacocoTestReport {
     }
 }
 
-group = 'com.github.stickerifier'
-version = '1.0'
-description = 'Telegram bot to convert medias in the format required to be used as Telegram stickers'
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(23)
-    }
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8'
-}
-
-test {
-    dependsOn('runtime')
-    useJUnitPlatform()
-    finalizedBy(jacocoTestReport)
-
-    def file = DefaultNativePlatform.currentOperatingSystem.isWindows() ? 'java.exe' : 'java'
-    executable = layout.buildDirectory.file('jre/bin/' + file).get()
-}
-
 application {
     mainClass = 'com.github.stickerifier.stickerify.runner.Main'
 }
 
-runtime {
-    options = ['--strip-debug', '--no-header-files', '--no-man-pages']
-    modules = ['java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec', 'jdk.unsupported']
-}
-
 shadowJar {
-    archiveBaseName = 'Stickerify'
-    archiveClassifier = 'shadow'
-    archiveVersion = ''
     mergeServiceFiles()
 
     dependencies {
         exclude('dist_webp_binaries/')
     }
 }
+
+runtime {
+    options = ['--compress', 'zip-9', '--no-header-files', '--no-man-pages', '--strip-debug']
+    modules = [ 'java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec', 'jdk.unsupported']
+}
+
+suggestModules.dependsOn shadowJar

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ shadowJar {
 
 runtime {
     options = ['--strip-debug', '--no-header-files', '--no-man-pages']
-    modules = ['java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec']
+    modules = ['java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec', 'jdk.unsupported']
 }
 
 suggestModules.dependsOn shadowJar

--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,15 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 test {
+    dependsOn 'runtime'
     useJUnitPlatform()
     finalizedBy(jacocoTestReport)
+
+    doFirst {
+        def javaExecutable = System.getProperty("os.name").toLowerCase().contains("windows") ? "java.exe" : "java"
+
+        executable = layout.buildDirectory.file("jre/bin/$javaExecutable").get().asFile.absolutePath
+    }
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ shadowJar {
 }
 
 runtime {
-    options = ['--compress', 'zip-9', '--strip-debug', '--no-header-files', '--no-man-pages']
+    options = ['--strip-debug', '--no-header-files', '--no-man-pages']
     modules = ['java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec']
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,8 +93,8 @@ shadowJar {
 }
 
 runtime {
-    options = ['--strip-debug', '--no-header-files', '--no-man-pages']
-    modules = [ 'java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec', 'jdk.unsupported']
+    options = ['--compress', 'zip-9', '--strip-debug', '--no-header-files', '--no-man-pages']
+    modules = ['java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec']
 }
 
 suggestModules.dependsOn shadowJar

--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,10 @@ tasks.withType(JavaCompile).configureEach {
 
 test {
     dependsOn jre
+    inputs.dir tasks.jre.jreDir
 
     def file = DefaultNativePlatform.currentOperatingSystem.isWindows() ? 'java.exe' : 'java'
-    executable = layout.buildDirectory.file('jre/bin/' + file).get()
+    executable = tasks.jre.jreDir.file('bin/' + file)
 
     useJUnitPlatform()
     finalizedBy jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ tasks.withType(JavaCompile).configureEach {
 
 test {
     dependsOn jre
-    inputs.files jre.outputs.files
 
     def file = DefaultNativePlatform.currentOperatingSystem.isWindows() ? 'java.exe' : 'java'
     executable = layout.buildDirectory.file('jre/bin/' + file).get()
@@ -94,7 +93,7 @@ shadowJar {
 }
 
 runtime {
-    options = ['--compress', 'zip-9', '--no-header-files', '--no-man-pages', '--strip-debug']
+    options = ['--strip-debug', '--no-header-files', '--no-man-pages']
     modules = [ 'java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec', 'jdk.unsupported']
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     alias(libs.plugins.runtime)
     alias(libs.plugins.shadow)
@@ -69,15 +71,12 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 test {
-    dependsOn 'runtime'
+    dependsOn('runtime')
     useJUnitPlatform()
     finalizedBy(jacocoTestReport)
 
-    doFirst {
-        def javaExecutable = System.getProperty("os.name").toLowerCase().contains("windows") ? "java.exe" : "java"
-
-        executable = layout.buildDirectory.file("jre/bin/$javaExecutable").get().asFile.absolutePath
-    }
+    def file = DefaultNativePlatform.currentOperatingSystem.isWindows() ? 'java.exe' : 'java'
+    executable = layout.buildDirectory.file('jre/bin/' + file).get()
 }
 
 application {
@@ -86,7 +85,7 @@ application {
 
 runtime {
     options = ['--strip-debug', '--no-header-files', '--no-man-pages']
-    modules = ['java.desktop', 'java.naming', 'java.sql', 'jdk.crypto.ec', 'jdk.unsupported']
+    modules = ['java.desktop', 'java.instrument', 'java.naming', 'java.sql', 'jdk.crypto.ec', 'jdk.unsupported']
 }
 
 shadowJar {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,5 +24,5 @@ telegram-bot-api = "com.github.pengrad:java-telegram-bot-api:8.3.0"
 tika = "org.apache.tika:tika-core:3.1.0"
 
 [plugins]
-runtime = "org.beryx.runtime:1.13.1"
+runtime = "com.dua3.gradle.runtime:1.13.1-patch-1"
 shadow = "com.gradleup.shadow:8.3.6"


### PR DESCRIPTION
The recent upgrade of the Java Telegram Bot API library highlighted the need to include `jdk.unsupported` among imported modules in the custom JRE generated to execute the bot, as reported in https://github.com/pengrad/java-telegram-bot-api/issues/421.

To tackle this sort of issues before they reach the production environment, we need to use the very same custom JRE to run tests (both locally and on CICD).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified the container configuration to streamline the build process and ensure the correct application package is executed.
  - Enhanced the build setup with improved test configurations for better compatibility across platforms and upgraded a runtime dependency for increased robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->