### PR TITLE
Disable ZGC as default garbage collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY --from=builder /app/libwebp/bin/dwebp /usr/local/bin/
 COPY --from=builder /app/build/jre jre
 COPY --from=builder /app/build/libs/Stickerify-1.0-all.jar Stickerify.jar
 
-CMD ["jre/bin/java", "-XX:+UseZGC", "-Dcom.sksamuel.scrimage.webp.binary.dir=/usr/local/bin/", "-jar", "Stickerify.jar"]
+CMD ["jre/bin/java", "-Dcom.sksamuel.scrimage.webp.binary.dir=/usr/local/bin/", "-jar", "Stickerify.jar"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Java runtime command in the Docker container by removing the Z Garbage Collector (ZGC) option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->