### PR TITLE
Configure ShadowJar after recent breaking changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.transformers.PreserveFirstFoundResourceTransformer
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -131,24 +130,16 @@ application {
 shadowJar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
-
-    transform(PreserveFirstFoundResourceTransformer) {
-        resources.addAll(
-                'META-INF/LICENSE',
-                'META-INF/LICENSE.txt',
-                'META-INF/NOTICE',
-                'META-INF/NOTICE.txt',
-                'license/LICENSE',
-                'license/LICENSE.dom-documentation.txt',
-                'license/LICENSE.dom-software.txt',
-                'license/NOTICE',
-                'license/README.dom.txt'
-        )
-    }
-
     failOnDuplicateEntries = true
 
-    dependencies {
-        exclude('dist_webp_binaries/')
-    }
+    exclude('dist_webp_binaries/',
+            'META-INF/LICENSE',
+            'META-INF/LICENSE.txt',
+            'META-INF/NOTICE',
+            'META-INF/NOTICE.txt',
+            'license/LICENSE',
+            'license/LICENSE.dom-documentation.txt',
+            'license/LICENSE.dom-software.txt',
+            'license/NOTICE',
+            'license/README.dom.txt')
 }


### PR DESCRIPTION
This has been caused by #387 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Improved shaded JAR packaging for more reliable builds and clearer duplicate handling.
  - Packaging now excludes common licence and metadata files from bundled dependencies to reduce noise in the final artefact.
  - Duplicate-entry handling adjusted to permit intended duplicates but fail the build if unresolved conflicts remain.
  - Changes are limited to packaging behaviour; no runtime task configurations were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->