### PR TITLE
Prevent animated WebP conversion failures

### DIFF
--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -290,6 +290,7 @@ public final class MediaHelper {
 
 	/**
 	 * Checks if the MIME type corresponds to one of the supported image formats.
+	 * If the image file is an animated WebP, {@code false} is returned as they are not currently supported.
 	 *
 	 * @param image the image file to check
 	 * @param mimeType the MIME type to check

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -10,6 +10,7 @@ import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDE
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FILE_SIZE;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.MAX_VIDEO_FRAMES;
 import static com.github.stickerifier.stickerify.media.MediaConstraints.VP9_CODEC;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.stickerifier.stickerify.exception.CorruptedFileException;
@@ -45,6 +46,12 @@ public final class MediaHelper {
 
 	private static final int IMAGE_KEEP_ASPECT_RATIO = -1;
 	private static final int VIDEO_KEEP_ASPECT_RATIO = -2;
+
+	private static final int WEBP_CHUNK_TYPE_OFFSET = 12;
+	private static final int WEBP_CHUNK_TYPE_LENGTH = 4;
+	private static final int WEBP_FLAGS_BYTE_OFFSET = 20;
+	private static final int WEBP_ANIMATION_BIT_MASK = 0x02;
+	private static final String WEBP_EXTENDED_FILE_FORMAT = "VP8X";
 
 	/**
 	 * Based on the type of passed-in file, it converts it into the proper media.
@@ -313,15 +320,16 @@ public final class MediaHelper {
 	 */
 	private static boolean isAnimatedWebp(File file) {
 		try (var fileInputStream = new FileInputStream(file)) {
-			var header = new byte[256];
-			int bytesRead = fileInputStream.read(header);
-
-			if (bytesRead < 32) {
+			var header = new byte[WEBP_FLAGS_BYTE_OFFSET + 1];
+			if (fileInputStream.read(header) < 21) {
 				return false;
 			}
 
-			var headerContent = new String(header, UTF_8);
-			return headerContent.contains("ANIM");
+			var chunkHeader = new String(header, WEBP_CHUNK_TYPE_OFFSET, WEBP_CHUNK_TYPE_LENGTH, ISO_8859_1);
+			boolean isExtendedFormat = WEBP_EXTENDED_FILE_FORMAT.equals(chunkHeader);
+			boolean hasAnimationFlag = (header[WEBP_FLAGS_BYTE_OFFSET] & WEBP_ANIMATION_BIT_MASK) != 0;
+
+			return isExtendedFormat && hasAnimationFlag;
 		} catch (IOException e) {
 			LOGGER.atWarn().setCause(e).log("An error occurred checking if the file is an animated WebP");
 			return false;

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -73,7 +73,7 @@ public final class MediaHelper {
 				return null;
 			}
 
-			if (mimeType.startsWith("image/")) {
+			if (isSupportedImage(inputFile, mimeType)) {
 				if (isImageCompliant(inputFile, mimeType)) {
 					LOGGER.atInfo().log("The image doesn't need conversion");
 					return null;
@@ -286,6 +286,45 @@ public final class MediaHelper {
 				&& animation.duration() <= MAX_ANIMATION_DURATION_SECONDS
 				&& animation.width() == MAX_SIDE_LENGTH
 				&& animation.height() == MAX_SIDE_LENGTH;
+	}
+
+	/**
+	 * Checks if the MIME type corresponds to one of the supported image formats.
+	 *
+	 * @param image the image file to check
+	 * @param mimeType the MIME type to check
+	 * @return {@code true} if the MIME type is supported
+	 */
+	private static boolean isSupportedImage(File image, String mimeType) {
+		if ("image/webp".equals(mimeType) && isAnimatedWebp(image)) {
+			LOGGER.atInfo().log("The image is an animated WebP");
+			return false;
+		}
+
+		return mimeType.startsWith("image/");
+	}
+
+	/**
+	 * Detects if a WebP file is animated by checking its file header.
+	 *
+	 * @param file the WebP file to check
+	 * @return {@code true} if the file is an animated WebP
+	 */
+	private static boolean isAnimatedWebp(File file) {
+		try (var fileInputStream = new FileInputStream(file)) {
+			var header = new byte[256];
+			int bytesRead = fileInputStream.read(header);
+
+			if (bytesRead < 32) {
+				return false;
+			}
+
+			var headerContent = new String(header, UTF_8);
+			return headerContent.contains("ANIM");
+		} catch (IOException e) {
+			LOGGER.atWarn().setCause(e).log("An error occurred checking if the file is an animated WebP");
+			return false;
+		}
 	}
 
 	/**

--- a/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
+++ b/src/main/java/com/github/stickerifier/stickerify/media/MediaHelper.java
@@ -50,6 +50,7 @@ public final class MediaHelper {
 	private static final int WEBP_CHUNK_TYPE_OFFSET = 12;
 	private static final int WEBP_CHUNK_TYPE_LENGTH = 4;
 	private static final int WEBP_FLAGS_BYTE_OFFSET = 20;
+	private static final int WEBP_HEADER_SIZE = 21;
 	private static final int WEBP_ANIMATION_BIT_MASK = 0x02;
 	private static final String WEBP_EXTENDED_FILE_FORMAT = "VP8X";
 
@@ -320,8 +321,8 @@ public final class MediaHelper {
 	 */
 	private static boolean isAnimatedWebp(File file) {
 		try (var fileInputStream = new FileInputStream(file)) {
-			var header = new byte[WEBP_FLAGS_BYTE_OFFSET + 1];
-			if (fileInputStream.read(header) < 21) {
+			var header = fileInputStream.readNBytes(WEBP_HEADER_SIZE);
+			if (header.length < WEBP_HEADER_SIZE) {
 				return false;
 			}
 

--- a/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/media/MediaHelperTest.java
@@ -260,7 +260,7 @@ class MediaHelperTest {
 		var webpVideo = loadResource("animated.webp");
 
 		var ex = assertThrows(MediaException.class, () -> MediaHelper.convert(webpVideo));
-		assertThat(ex.getMessage(), equalTo("FFmpeg image conversion failed"));
+		assertThat(ex.getMessage(), equalTo("The file with image/webp MIME type is not supported"));
 	}
 
 	@Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Animated WebP images are now explicitly detected and reported as unsupported, returning a clearer, specific error message when conversion isn't attempted.
* **Tests**
  * Updated test expectations to validate the new unsupported-WebP error message for animated WebP cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->