### PR TITLE
Switch replies to rich text

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ test {
     useJUnitPlatform()
 
     testLogging {
-        events('passed', 'failed', 'skipped')
+        events('started', 'passed', 'failed', 'skipped')
     }
 }
 

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -215,9 +215,8 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 	}
 
 	private void answerText(Answer answer, TelegramRequest request) {
-		var answerWithText = new SendRichMessage(request.getChatId(), new InputRichMessage().markdown(answer.getText()))
-				.replyParameters(new ReplyParameters(request.getMessageId()))
-				.disableNotification(true);
+		var message = new InputRichMessage().markdown(answer.getText());
+		var answerWithText = new SendRichMessage(request.getChatId(), message).disableNotification(true);
 
 		try {
 			execute(answerWithText);

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -148,8 +148,8 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 						.replyParameters(new ReplyParameters(request.getMessageId()))
 						.disableContentTypeDetection(true);
 
-				answerText(FILE_READY, request);
 				execute(answerWithFile);
+				answerText(FILE_READY, request);
 			}
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -8,6 +8,7 @@ import static com.github.stickerifier.stickerify.telegram.Answer.ERROR;
 import static com.github.stickerifier.stickerify.telegram.Answer.FILE_ALREADY_VALID;
 import static com.github.stickerifier.stickerify.telegram.Answer.FILE_READY;
 import static com.github.stickerifier.stickerify.telegram.Answer.FILE_TOO_LARGE;
+import static com.github.stickerifier.stickerify.telegram.Answer.PROCESSING;
 import static com.pengrad.telegrambot.model.request.ParseMode.MarkdownV2;
 import static java.util.HashSet.newHashSet;
 import static java.util.concurrent.Executors.newThreadPerTaskExecutor;
@@ -23,14 +24,15 @@ import com.pengrad.telegrambot.ExceptionHandler;
 import com.pengrad.telegrambot.TelegramBot;
 import com.pengrad.telegrambot.TelegramException;
 import com.pengrad.telegrambot.UpdatesListener;
-import com.pengrad.telegrambot.model.LinkPreviewOptions;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.model.request.ReplyParameters;
+import com.pengrad.telegrambot.model.request.richmessages.InputRichMessage;
 import com.pengrad.telegrambot.request.BaseRequest;
 import com.pengrad.telegrambot.request.GetFile;
 import com.pengrad.telegrambot.request.GetUpdates;
 import com.pengrad.telegrambot.request.SendDocument;
-import com.pengrad.telegrambot.request.SendMessage;
+import com.pengrad.telegrambot.request.richmessages.SendRichMessage;
+import com.pengrad.telegrambot.request.richmessages.SendRichMessageDraft;
 import com.pengrad.telegrambot.response.BaseResponse;
 import org.slf4j.event.Level;
 
@@ -54,6 +56,7 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 	private static final StructuredLogger LOGGER = new StructuredLogger(Stickerify.class);
 	private static final String BOT_TOKEN = System.getenv("STICKERIFY_TOKEN");
 	private static final ThreadFactory VIRTUAL_THREAD_FACTORY = Thread.ofVirtual().name("Virtual-", 0).factory();
+	private static final InputRichMessage PROCESSING_MESSAGE = new InputRichMessage().html(PROCESSING.getText());
 
 	/**
 	 * Instantiate the bot processing requests with virtual threads.
@@ -127,8 +130,11 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 
 	private void answerFile(TelegramRequest request, String fileId) {
 		Set<Path> pathsToDelete = newHashSet(2);
+		var processingMessage = new SendRichMessageDraft(request.getChatId(), 1, PROCESSING_MESSAGE);
 
 		try {
+			execute(processingMessage);
+
 			var originalFile = retrieveFile(fileId);
 			pathsToDelete.add(originalFile.toPath());
 
@@ -209,12 +215,9 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 	}
 
 	private void answerText(Answer answer, TelegramRequest request) {
-		var previewOptions = new LinkPreviewOptions().isDisabled(answer.isDisableLinkPreview());
-
-		var answerWithText = new SendMessage(request.getChatId(), answer.getText())
+		var answerWithText = new SendRichMessage(request.getChatId(), new InputRichMessage().markdown(answer.getText()))
 				.replyParameters(new ReplyParameters(request.getMessageId()))
-				.parseMode(MarkdownV2)
-				.linkPreviewOptions(previewOptions);
+				.disableNotification(true);
 
 		try {
 			execute(answerWithText);

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -9,7 +9,6 @@ import static com.github.stickerifier.stickerify.telegram.Answer.FILE_ALREADY_VA
 import static com.github.stickerifier.stickerify.telegram.Answer.FILE_READY;
 import static com.github.stickerifier.stickerify.telegram.Answer.FILE_TOO_LARGE;
 import static com.github.stickerifier.stickerify.telegram.Answer.PROCESSING;
-import static com.pengrad.telegrambot.model.request.ParseMode.MarkdownV2;
 import static java.util.HashSet.newHashSet;
 import static java.util.concurrent.Executors.newThreadPerTaskExecutor;
 
@@ -147,10 +146,9 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 
 				var answerWithFile = new SendDocument(request.getChatId(), outputFile)
 						.replyParameters(new ReplyParameters(request.getMessageId()))
-						.disableContentTypeDetection(true)
-						.caption(FILE_READY.getText())
-						.parseMode(MarkdownV2);
+						.disableContentTypeDetection(true);
 
+				answerText(FILE_READY, request);
 				execute(answerWithFile);
 			}
 		} catch (InterruptedException e) {

--- a/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
+++ b/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
@@ -9,11 +9,10 @@ public enum Answer {
 			Send me the media you want to convert and I will take care of the rest.
 
 			Based on what you send, I will answer the following:
-			- the converted media, if you sent a supported file (images, gifs, standard and video stickers are supported)
+			- the converted media, if you sent a supported file (use the **/supported** command to read the full list)
 			- no file, if you sent a media already suiting Telegram's requirements
 			- an error message, if you sent either an unsupported or a corrupted file
 			- an informative message for any message without a file
-			- the list of supported files, using the /supported command
 
 			Once the file is ready, head to [Stickers bot](https://t.me/Stickers) to create a new sticker.
 			"""),
@@ -35,7 +34,7 @@ public enum Answer {
 			Looking for sticker packs? Try [MeminiCustom](https://t.me/addstickers/MeminiCustom) and [VideoMemini](https://t.me/addstickers/VideoMemini)!
 			"""),
 	ERROR("""
-			The file conversion was unsuccessful: only images, gifs, standard and video stickers are supported.
+			The file conversion was unsuccessful: use the **/supported** command to read the full list of supported files.
 
 			If you think it should have worked, please report the issue on [GitHub](https://github.com/Stickerifier/Stickerify/issues/new/choose).
 			"""),

--- a/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
+++ b/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
@@ -6,60 +6,53 @@ package com.github.stickerifier.stickerify.telegram;
 public enum Answer {
 
 	HELP("""
-			Send me the media you want to convert and I will take care of the rest\\.
+			Send me the media you want to convert and I will take care of the rest.
 
 			Based on what you send, I will answer the following:
-			\\- the converted media, if you sent a supported file \\(images, gifs, standard and video stickers are supported\\)
-			\\- no file, if you sent a media already suiting Telegram's requirements
-			\\- an error message, if you sent either an unsupported or a corrupted file
-			\\- an informative message for any message without a file
+			- the converted media, if you sent a supported file (images, gifs, standard and video stickers are supported)
+			- no file, if you sent a media already suiting Telegram's requirements
+			- an error message, if you sent either an unsupported or a corrupted file
+			- an informative message for any message without a file
 
-			Once the file is ready, head to [Stickers](https://t.me/Stickers) to create a new sticker\\.
+			Once the file is ready, head to [Stickers](https://t.me/Stickers) to create a new sticker.
 			"""),
 	FILE_READY("""
 			Your sticker file is ready\\!
 			Head to [Stickers](https://t.me/Stickers) to create a new sticker\\.
 			"""),
 	FILE_ALREADY_VALID("""
-			The media you sent was already suitable to be a Telegram sticker\\.
-			Send it to [Stickers](https://t.me/Stickers) to add it as a new sticker\\.
+			The media you sent was already suitable to be a Telegram sticker.
+			Send it to [Stickers](https://t.me/Stickers) to add it as a new sticker.
 			"""),
 	FILE_TOO_LARGE("""
-			The file can't be converted because Telegram bots can't handle files larger than 20 MB at the moment: please send a smaller one\\.
+			The file can't be converted because Telegram bots can't handle files larger than 20 MB at the moment: please send a smaller one.
 			"""),
 	ABOUT("""
-			This bot is open source, check it out on [Github](https://github.com/Stickerifier/Stickerify)\\.
+			This bot is open source, check it out on [Github](https://github.com/Stickerifier/Stickerify).
 
-			Looking for sticker packs? Try [MeminiCustom](https://t.me/addstickers/MeminiCustom) and [VideoMemini](https://t.me/addstickers/VideoMemini)\\!
+			Looking for sticker packs? Try [MeminiCustom](https://t.me/addstickers/MeminiCustom) and [VideoMemini](https://t.me/addstickers/VideoMemini)!
 			"""),
 	ERROR("""
-			The file conversion was unsuccessful: only images, gifs, standard and video stickers are supported\\.
+			The file conversion was unsuccessful: only images, gifs, standard and video stickers are supported.
 
-			If you think it should have worked, please report the issue on [Github](https://github.com/Stickerifier/Stickerify/issues/new/choose)\\.
-			""", true),
+			If you think it should have worked, please report the issue on [Github](https://github.com/Stickerifier/Stickerify/issues/new/choose).
+			"""),
 	PRIVACY_POLICY("""
-			You can view our privacy policy by visiting [this link](https://stickerifier.github.io/Stickerify/PRIVACY_POLICY.html)\\.
+			You can view our privacy policy by visiting [this link](https://stickerifier.github.io/Stickerify/PRIVACY_POLICY.html).
 
-			If you have any questions or concerns, feel free to reach out to us\\.
+			If you have any questions or concerns, feel free to reach out to us.
+			"""),
+	PROCESSING("""
+			<tg-thinking>Processing file...</tg-thinking>
 			""");
 
 	private final String text;
-	private final boolean disableLinkPreview;
 
 	Answer(String text) {
-		this(text, false);
-	}
-
-	Answer(String text, boolean disableLinkPreview) {
 		this.text = text;
-		this.disableLinkPreview = disableLinkPreview;
 	}
 
 	public String getText() {
 		return text;
-	}
-
-	public boolean isDisableLinkPreview() {
-		return disableLinkPreview;
 	}
 }

--- a/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
+++ b/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
@@ -13,6 +13,7 @@ public enum Answer {
 			- no file, if you sent a media already suiting Telegram's requirements
 			- an error message, if you sent either an unsupported or a corrupted file
 			- an informative message for any message without a file
+			- the list of supported files, using the /supported command
 
 			Once the file is ready, head to [Stickers](https://t.me/Stickers) to create a new sticker.
 			"""),
@@ -28,14 +29,14 @@ public enum Answer {
 			The file can't be converted because Telegram bots can't handle files larger than 20 MB at the moment: please send a smaller one.
 			"""),
 	ABOUT("""
-			This bot is open source, check it out on [Github](https://github.com/Stickerifier/Stickerify).
+			This bot is open source, check it out on [GitHub](https://github.com/Stickerifier/Stickerify).
 
 			Looking for sticker packs? Try [MeminiCustom](https://t.me/addstickers/MeminiCustom) and [VideoMemini](https://t.me/addstickers/VideoMemini)!
 			"""),
 	ERROR("""
 			The file conversion was unsuccessful: only images, gifs, standard and video stickers are supported.
 
-			If you think it should have worked, please report the issue on [Github](https://github.com/Stickerifier/Stickerify/issues/new/choose).
+			If you think it should have worked, please report the issue on [GitHub](https://github.com/Stickerifier/Stickerify/issues/new/choose).
 			"""),
 	PRIVACY_POLICY("""
 			You can view our privacy policy by visiting [this link](https://stickerifier.github.io/Stickerify/PRIVACY_POLICY.html).
@@ -44,6 +45,53 @@ public enum Answer {
 			"""),
 	PROCESSING("""
 			<tg-thinking>Processing file...</tg-thinking>
+			"""),
+	SUPPORTED_FORMATS("""
+			### Supported formats
+
+			<details><summary>Images</summary>
+
+				| Format      | Support status |
+				|:------------|:--------------:|
+				| png         |       ✔        |
+				| jpg / jpeg  |       ✔        |
+				| static webp |       ✔        |
+				| tiff        |       ✔        |
+				| ico         |       ✔        |
+				| svg         |       ✔        |
+				| psd         |       ✔        |
+
+			</details>
+
+			<details><summary>Videos</summary>
+
+				| Format        | Support status |
+				|:--------------|:--------------:|
+				| gif           |       ✔        |
+				| mov           |       ✔        |
+				| avi           |       ✔        |
+				| mp4           |       ✔        |
+				| webm          |       ✔        |
+				| m4v           |       ✔        |
+				| mkv           |       ✔        |
+				| live photos   |       ✔        |
+				| animated webp |       ✖        |
+
+			</details>
+
+			<details><summary>Stickers</summary>
+
+				| Format                                                                     | Support status |
+				|:---------------------------------------------------------------------------|:--------------:|
+				| static, for instance [MeminiCustom](https://t.me/addstickers/MeminiCustom) |       ✔        |
+				| video, for instance [VideoMemini](https://t.me/addstickers/VideoMemini)    |       ✔        |
+				| animated, for instance [HotCherry](https://t.me/addstickers/HotCherry)     |       ✔        |
+
+			</details>
+
+			---
+
+			If you want to see a format added, please let us know by creating an issue on [GitHub](https://github.com/Stickerifier/Stickerify/issues/new).
 			""");
 
 	private final String text;

--- a/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
+++ b/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
@@ -40,7 +40,7 @@ public enum Answer {
 	PRIVACY_POLICY("""
 			You can view our privacy policy by visiting [this link](https://stickerifier.github.io/Stickerify/PRIVACY_POLICY.html).
 
-			If you have any questions or concerns, feel free to reach out to us.
+			If you have any questions or concerns, feel free to reach out to us at [stickerifier@gmail.com](mailto:stickerifier@gmail.com).
 			"""),
 	PROCESSING("""
 			<tg-thinking>Processing file...</tg-thinking>

--- a/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
+++ b/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
@@ -18,8 +18,9 @@ public enum Answer {
 			Once the file is ready, head to [Stickers bot](https://t.me/Stickers) to create a new sticker.
 			"""),
 	FILE_READY("""
-			Your sticker file is ready\\!
-			Head to [Stickers bot](https://t.me/Stickers) to create a new sticker\\.
+			Your sticker file is ready!
+
+			Head to [Stickers bot](https://t.me/Stickers) to create a new sticker.
 			"""),
 	FILE_ALREADY_VALID("""
 			The media you sent was already suitable to be a Telegram sticker.

--- a/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
+++ b/src/main/java/com/github/stickerifier/stickerify/telegram/Answer.java
@@ -15,15 +15,15 @@ public enum Answer {
 			- an informative message for any message without a file
 			- the list of supported files, using the /supported command
 
-			Once the file is ready, head to [Stickers](https://t.me/Stickers) to create a new sticker.
+			Once the file is ready, head to [Stickers bot](https://t.me/Stickers) to create a new sticker.
 			"""),
 	FILE_READY("""
 			Your sticker file is ready\\!
-			Head to [Stickers](https://t.me/Stickers) to create a new sticker\\.
+			Head to [Stickers bot](https://t.me/Stickers) to create a new sticker\\.
 			"""),
 	FILE_ALREADY_VALID("""
 			The media you sent was already suitable to be a Telegram sticker.
-			Send it to [Stickers](https://t.me/Stickers) to add it as a new sticker.
+			Send it to [Stickers bot](https://t.me/Stickers) to add it as a new sticker.
 			"""),
 	FILE_TOO_LARGE("""
 			The file can't be converted because Telegram bots can't handle files larger than 20 MB at the moment: please send a smaller one.
@@ -47,47 +47,11 @@ public enum Answer {
 			<tg-thinking>Processing file...</tg-thinking>
 			"""),
 	SUPPORTED_FORMATS("""
-			### Supported formats
-
-			<details><summary>Images</summary>
-
-				| Format      | Support status |
-				|:------------|:--------------:|
-				| png         |       ✔        |
-				| jpg / jpeg  |       ✔        |
-				| static webp |       ✔        |
-				| tiff        |       ✔        |
-				| ico         |       ✔        |
-				| svg         |       ✔        |
-				| psd         |       ✔        |
-
-			</details>
-
-			<details><summary>Videos</summary>
-
-				| Format        | Support status |
-				|:--------------|:--------------:|
-				| gif           |       ✔        |
-				| mov           |       ✔        |
-				| avi           |       ✔        |
-				| mp4           |       ✔        |
-				| webm          |       ✔        |
-				| m4v           |       ✔        |
-				| mkv           |       ✔        |
-				| live photos   |       ✔        |
-				| animated webp |       ✖        |
-
-			</details>
-
-			<details><summary>Stickers</summary>
-
-				| Format                                                                     | Support status |
-				|:---------------------------------------------------------------------------|:--------------:|
-				| static, for instance [MeminiCustom](https://t.me/addstickers/MeminiCustom) |       ✔        |
-				| video, for instance [VideoMemini](https://t.me/addstickers/VideoMemini)    |       ✔        |
-				| animated, for instance [HotCherry](https://t.me/addstickers/HotCherry)     |       ✔        |
-
-			</details>
+			| Type     | Supported formats                               |
+			|:---------|:------------------------------------------------|
+			| images   | png, jpg, static webp, tiff, ico, svg, psd      |
+			| videos   | gif, mov, avi, mp4, webm, m4v, mkv, live photos |
+			| stickers | static, video, animated                         |
 
 			---
 

--- a/src/main/java/com/github/stickerifier/stickerify/telegram/model/TelegramRequest.java
+++ b/src/main/java/com/github/stickerifier/stickerify/telegram/model/TelegramRequest.java
@@ -3,6 +3,7 @@ package com.github.stickerifier.stickerify.telegram.model;
 import static com.github.stickerifier.stickerify.telegram.Answer.ABOUT;
 import static com.github.stickerifier.stickerify.telegram.Answer.HELP;
 import static com.github.stickerifier.stickerify.telegram.Answer.PRIVACY_POLICY;
+import static com.github.stickerifier.stickerify.telegram.Answer.SUPPORTED_FORMATS;
 import static java.util.Comparator.comparing;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +32,7 @@ public record TelegramRequest(Message message) {
 	private static final String START_COMMAND = "/start";
 	private static final String HELP_COMMAND = "/help";
 	private static final String PRIVACY_COMMAND = "/privacy";
+	private static final String SUPPORTED_COMMAND = "/supported";
 
 	public @Nullable TelegramFile getFile() {
 		return getMessageMedia()
@@ -82,6 +84,7 @@ public record TelegramRequest(Message message) {
 		return switch (message.text()) {
 			case HELP_COMMAND, START_COMMAND -> HELP;
 			case PRIVACY_COMMAND -> PRIVACY_POLICY;
+			case SUPPORTED_COMMAND -> SUPPORTED_FORMATS;
 			case null, default -> ABOUT;
 		};
 	}

--- a/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
@@ -76,6 +76,27 @@ public final class MockResponses {
 			}
 			""").build();
 
+	static final MockResponse SUPPORTED_MESSAGE = new MockResponse.Builder().body("""
+			{
+				ok: true,
+				result: [
+					{
+						update_id: 1,
+						message: {
+							message_id: 1,
+							from: {
+								id: 123456
+							},
+							chat: {
+								id: 1
+							},
+							text: "/supported"
+						}
+					}
+				]
+			}
+			""").build();
+
 	static final MockResponse FILE_NOT_SUPPORTED = new MockResponse.Builder().body("""
 			{
 				ok: true,

--- a/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
@@ -7,7 +7,7 @@ import okio.Okio;
 
 public final class MockResponses {
 
-	static final MockResponse EMPTY_UPDATES = new MockResponse.Builder().body("""
+	static final MockResponse EMPTY_RESPONSE = new MockResponse.Builder().body("""
 			{
 				ok: true
 			}

--- a/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
@@ -7,7 +7,7 @@ import okio.Okio;
 
 public final class MockResponses {
 
-	static final MockResponse EMPTY_RESPONSE = new MockResponse.Builder().body("""
+	static final MockResponse SUCCESS_RESPONSE = new MockResponse.Builder().body("""
 			{
 				ok: true
 			}

--- a/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
@@ -114,6 +114,20 @@ class StickerifyTest {
 	}
 
 	@Test
+	void supportedMessage() throws Exception {
+		server.enqueue(MockResponses.SUPPORTED_MESSAGE);
+
+		try (var _ = runBot()) {
+			var getUpdates = server.takeRequest();
+			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.SUPPORTED_FORMATS);
+		}
+	}
+
+	@Test
 	void fileNotSupported() throws Exception {
 		server.enqueue(MockResponses.FILE_NOT_SUPPORTED);
 

--- a/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
@@ -30,7 +30,7 @@ class StickerifyTest {
 
 	@BeforeEach
 	void setup() {
-		((QueueDispatcher) server.getDispatcher()).setFailFast(MockResponses.EMPTY_RESPONSE);
+		((QueueDispatcher) server.getDispatcher()).setFailFast(MockResponses.SUCCESS_RESPONSE);
 	}
 
 	@Test
@@ -158,7 +158,7 @@ class StickerifyTest {
 	@Test
 	void fileAlreadyValid() throws Exception {
 		server.enqueue(MockResponses.ANIMATED_STICKER);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("animated_sticker.tgs"));
 		server.enqueue(MockResponses.fileDownload("animated_sticker.tgs"));
 
@@ -187,7 +187,7 @@ class StickerifyTest {
 	@Test
 	void convertedPng() throws Exception {
 		server.enqueue(MockResponses.PNG_FILE);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("big.png"));
 		server.enqueue(MockResponses.fileDownload("big.png"));
 
@@ -207,17 +207,19 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/big.png", download.getTarget());
 
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
+
 			var sendDocument = server.takeRequest();
 			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
-			assertNotNull(sendDocument.getBody());
-			assertThat(sendDocument.getBody().utf8(), containsString(Answer.FILE_READY.getText()));
 		}
 	}
 
 	@Test
 	void convertedWebp() throws Exception {
 		server.enqueue(MockResponses.WEBP_FILE);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("static.webp"));
 		server.enqueue(MockResponses.fileDownload("static.webp"));
 
@@ -237,17 +239,19 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/static.webp", download.getTarget());
 
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
+
 			var sendDocument = server.takeRequest();
 			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
-			assertNotNull(sendDocument.getBody());
-			assertThat(sendDocument.getBody().utf8(), containsString(Answer.FILE_READY.getText()));
 		}
 	}
 
 	@Test
 	void convertedMov() throws Exception {
 		server.enqueue(MockResponses.MOV_FILE);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("long.mov"));
 		server.enqueue(MockResponses.fileDownload("long.mov"));
 
@@ -267,17 +271,19 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/long.mov", download.getTarget());
 
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
+
 			var sendDocument = server.takeRequest();
 			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
-			assertNotNull(sendDocument.getBody());
-			assertThat(sendDocument.getBody().utf8(), containsString(Answer.FILE_READY.getText()));
 		}
 	}
 
 	@Test
 	void convertedWebm() throws Exception {
 		server.enqueue(MockResponses.WEBM_FILE);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("short_low_fps.webm"));
 		server.enqueue(MockResponses.fileDownload("short_low_fps.webm"));
 
@@ -297,17 +303,19 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/short_low_fps.webm", download.getTarget());
 
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
+
 			var sendDocument = server.takeRequest();
 			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
-			assertNotNull(sendDocument.getBody());
-			assertThat(sendDocument.getBody().utf8(), containsString(Answer.FILE_READY.getText()));
 		}
 	}
 
 	@Test
 	void convertedGif() throws Exception {
 		server.enqueue(MockResponses.GIF_FILE);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("valid.gif"));
 		server.enqueue(MockResponses.fileDownload("valid.gif"));
 
@@ -327,17 +335,19 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/valid.gif", download.getTarget());
 
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
+
 			var sendDocument = server.takeRequest();
 			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
-			assertNotNull(sendDocument.getBody());
-			assertThat(sendDocument.getBody().utf8(), containsString(Answer.FILE_READY.getText()));
 		}
 	}
 
 	@Test
 	void convertedLivePhoto() throws Exception {
 		server.enqueue(MockResponses.LIVE_PHOTO_FILE);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("valid_live_photo"));
 		server.enqueue(MockResponses.fileDownload("valid_live_photo"));
 
@@ -357,17 +367,19 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/valid_live_photo", download.getTarget());
 
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
+
 			var sendDocument = server.takeRequest();
 			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
-			assertNotNull(sendDocument.getBody());
-			assertThat(sendDocument.getBody().utf8(), containsString(Answer.FILE_READY.getText()));
 		}
 	}
 
 	@Test
 	void documentNotSupported() throws Exception {
 		server.enqueue(MockResponses.DOCUMENT);
-		server.enqueue(MockResponses.EMPTY_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("document.txt"));
 		server.enqueue(MockResponses.fileDownload("document.txt"));
 

--- a/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.github.stickerifier.stickerify.junit.ClearTempFiles;
 import com.github.stickerifier.stickerify.junit.Tags;
 import com.github.stickerifier.stickerify.telegram.Answer;
+import com.google.gson.JsonParser;
 import com.pengrad.telegrambot.TelegramBot;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.QueueDispatcher;
@@ -18,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.net.URLEncoder;
+import java.net.URLDecoder;
 
 @Tag(Tags.TELEGRAM_API)
 @ClearTempFiles
@@ -29,7 +30,7 @@ class StickerifyTest {
 
 	@BeforeEach
 	void setup() {
-		((QueueDispatcher) server.getDispatcher()).setFailFast(MockResponses.EMPTY_UPDATES);
+		((QueueDispatcher) server.getDispatcher()).setFailFast(MockResponses.EMPTY_RESPONSE);
 	}
 
 	@Test
@@ -40,9 +41,9 @@ class StickerifyTest {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
 
-			var sendMessage = server.takeRequest();
-			assertEquals("/api/token/sendMessage", sendMessage.getTarget());
-			assertResponseContainsMessage(sendMessage, Answer.HELP);
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.HELP);
 		}
 	}
 
@@ -56,10 +57,32 @@ class StickerifyTest {
 		return new Stickerify(bot, Runnable::run);
 	}
 
-	private static void assertResponseContainsMessage(RecordedRequest request, Answer answer) {
-		var message = URLEncoder.encode(answer.getText(), UTF_8);
+	private static void assertResponseContainsMarkdownMessage(RecordedRequest request, Answer answer) {
+		assertResponseContainsMessage(request, answer, "markdown");
+	}
+
+	private static void assertResponseContainsHtmlMessage(RecordedRequest request) {
+		assertResponseContainsMessage(request, Answer.PROCESSING, "html");
+	}
+
+	private static void assertResponseContainsMessage(RecordedRequest request, Answer answer, String messageFormat) {
 		assertNotNull(request.getBody());
-		assertThat(request.getBody().utf8(), containsString(message));
+		var decodedBody = URLDecoder.decode(request.getBody().utf8(), UTF_8);
+
+		var richMessageStart = decodedBody.indexOf("rich_message=");
+		if (richMessageStart == -1) {
+			throw new AssertionError("No rich message found in request body");
+		}
+
+		var richMessageEnd = decodedBody.indexOf("&", richMessageStart);
+		richMessageEnd = richMessageEnd == -1 ? decodedBody.length() : richMessageEnd;
+		var richMessageJson = decodedBody.substring(richMessageStart + "rich_message=".length(), richMessageEnd);
+
+		var richMessage = JsonParser.parseString(richMessageJson).getAsJsonObject();
+		var actualMessage = richMessage.get(messageFormat).getAsString();
+
+		var expectedMessage = answer.getText();
+		assertThat(actualMessage, containsString(expectedMessage));
 	}
 
 	@Test
@@ -70,9 +93,9 @@ class StickerifyTest {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
 
-			var sendMessage = server.takeRequest();
-			assertEquals("/api/token/sendMessage", sendMessage.getTarget());
-			assertResponseContainsMessage(sendMessage, Answer.HELP);
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.HELP);
 		}
 	}
 
@@ -84,9 +107,9 @@ class StickerifyTest {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
 
-			var sendMessage = server.takeRequest();
-			assertEquals("/api/token/sendMessage", sendMessage.getTarget());
-			assertResponseContainsMessage(sendMessage, Answer.PRIVACY_POLICY);
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.PRIVACY_POLICY);
 		}
 	}
 
@@ -98,9 +121,9 @@ class StickerifyTest {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
 
-			var sendMessage = server.takeRequest();
-			assertEquals("/api/token/sendMessage", sendMessage.getTarget());
-			assertResponseContainsMessage(sendMessage, Answer.ERROR);
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.ERROR);
 		}
 	}
 
@@ -112,21 +135,26 @@ class StickerifyTest {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
 
-			var sendMessage = server.takeRequest();
-			assertEquals("/api/token/sendMessage", sendMessage.getTarget());
-			assertResponseContainsMessage(sendMessage, Answer.FILE_TOO_LARGE);
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_TOO_LARGE);
 		}
 	}
 
 	@Test
 	void fileAlreadyValid() throws Exception {
 		server.enqueue(MockResponses.ANIMATED_STICKER);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("animated_sticker.tgs"));
 		server.enqueue(MockResponses.fileDownload("animated_sticker.tgs"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -136,21 +164,26 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/animated_sticker.tgs", download.getTarget());
 
-			var sendMessage = server.takeRequest();
-			assertEquals("/api/token/sendMessage", sendMessage.getTarget());
-			assertResponseContainsMessage(sendMessage, Answer.FILE_ALREADY_VALID);
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_ALREADY_VALID);
 		}
 	}
 
 	@Test
 	void convertedPng() throws Exception {
 		server.enqueue(MockResponses.PNG_FILE);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("big.png"));
 		server.enqueue(MockResponses.fileDownload("big.png"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -170,12 +203,17 @@ class StickerifyTest {
 	@Test
 	void convertedWebp() throws Exception {
 		server.enqueue(MockResponses.WEBP_FILE);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("static.webp"));
 		server.enqueue(MockResponses.fileDownload("static.webp"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -195,12 +233,17 @@ class StickerifyTest {
 	@Test
 	void convertedMov() throws Exception {
 		server.enqueue(MockResponses.MOV_FILE);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("long.mov"));
 		server.enqueue(MockResponses.fileDownload("long.mov"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -220,12 +263,17 @@ class StickerifyTest {
 	@Test
 	void convertedWebm() throws Exception {
 		server.enqueue(MockResponses.WEBM_FILE);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("short_low_fps.webm"));
 		server.enqueue(MockResponses.fileDownload("short_low_fps.webm"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -245,12 +293,17 @@ class StickerifyTest {
 	@Test
 	void convertedGif() throws Exception {
 		server.enqueue(MockResponses.GIF_FILE);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("valid.gif"));
 		server.enqueue(MockResponses.fileDownload("valid.gif"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -270,12 +323,17 @@ class StickerifyTest {
 	@Test
 	void convertedLivePhoto() throws Exception {
 		server.enqueue(MockResponses.LIVE_PHOTO_FILE);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("valid_live_photo"));
 		server.enqueue(MockResponses.fileDownload("valid_live_photo"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -295,12 +353,17 @@ class StickerifyTest {
 	@Test
 	void documentNotSupported() throws Exception {
 		server.enqueue(MockResponses.DOCUMENT);
+		server.enqueue(MockResponses.EMPTY_RESPONSE);
 		server.enqueue(MockResponses.fileInfo("document.txt"));
 		server.enqueue(MockResponses.fileDownload("document.txt"));
 
 		try (var _ = runBot()) {
 			var getUpdates = server.takeRequest();
 			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var sendRichMessageDraft = server.takeRequest();
+			assertEquals("/api/token/sendRichMessageDraft", sendRichMessageDraft.getTarget());
+			assertResponseContainsHtmlMessage(sendRichMessageDraft);
 
 			var getFile = server.takeRequest();
 			assertEquals("/api/token/getFile", getFile.getTarget());
@@ -310,9 +373,9 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/document.txt", download.getTarget());
 
-			var sendMessage = server.takeRequest();
-			assertEquals("/api/token/sendMessage", sendMessage.getTarget());
-			assertResponseContainsMessage(sendMessage, Answer.ERROR);
+			var sendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
+			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.ERROR);
 		}
 	}
 }

--- a/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
@@ -207,12 +207,12 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/big.png", download.getTarget());
 
+			var sendDocument = server.takeRequest();
+			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
+
 			var sendRichMessage = server.takeRequest();
 			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
 			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
-
-			var sendDocument = server.takeRequest();
-			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
 		}
 	}
 
@@ -239,12 +239,12 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/static.webp", download.getTarget());
 
+			var sendDocument = server.takeRequest();
+			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
+
 			var sendRichMessage = server.takeRequest();
 			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
 			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
-
-			var sendDocument = server.takeRequest();
-			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
 		}
 	}
 
@@ -271,12 +271,12 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/long.mov", download.getTarget());
 
+			var sendDocument = server.takeRequest();
+			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
+
 			var sendRichMessage = server.takeRequest();
 			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
 			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
-
-			var sendDocument = server.takeRequest();
-			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
 		}
 	}
 
@@ -303,12 +303,12 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/short_low_fps.webm", download.getTarget());
 
+			var sendDocument = server.takeRequest();
+			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
+
 			var sendRichMessage = server.takeRequest();
 			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
 			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
-
-			var sendDocument = server.takeRequest();
-			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
 		}
 	}
 
@@ -335,12 +335,12 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/valid.gif", download.getTarget());
 
+			var sendDocument = server.takeRequest();
+			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
+
 			var sendRichMessage = server.takeRequest();
 			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
 			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
-
-			var sendDocument = server.takeRequest();
-			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
 		}
 	}
 
@@ -367,12 +367,12 @@ class StickerifyTest {
 			var download = server.takeRequest();
 			assertEquals("/files/token/valid_live_photo", download.getTarget());
 
+			var sendDocument = server.takeRequest();
+			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
+
 			var sendRichMessage = server.takeRequest();
 			assertEquals("/api/token/sendRichMessage", sendRichMessage.getTarget());
 			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.FILE_READY);
-
-			var sendDocument = server.takeRequest();
-			assertEquals("/api/token/sendDocument", sendDocument.getTarget());
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **`/supported`** command to display supported file formats in a table.
  * The bot now sends a **processing/thinking** rich-message while converting files.
  * Improved reply formatting by switching relevant responses to **rich messages** for clearer styling.

* **Bug Fixes**
  * Updated completion responses to send **“file ready”** as a separate rich-text message (instead of as a document caption).

* **Tests**
  * Refreshed assertions and fixtures to validate **rich-message** payloads, including Markdown/HTML rendering, across the help/privacy/supported and error flows.

* **Chores**
  * Expanded test logging to include the **test started** lifecycle event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->