### PR TITLE
Disable coderabbit on bump prs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    ignore_title_keywords:
+      - "[bump]"

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -18,6 +18,6 @@ jobs:
       - name: Update dependencies
         uses: wader/bump/action@master
         with:
-          title_template: [bump] Update {{.Name}} to v{{.Latest}}
+          title_template: "[bump] Update {{.Name}} to v{{.Latest}}"
         env:
           GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -18,6 +18,6 @@ jobs:
       - name: Update dependencies
         uses: wader/bump/action@master
         with:
-          title_template: Update {{.Name}} to v{{.Latest}}
+          title_template: [bump] Update {{.Name}} to v{{.Latest}}
         env:
           GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}


### PR DESCRIPTION
Just treat them as any other prs from dependabot or similar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated code reviews with configuration to exclude dependency bump PRs from auto-review
  * Updated dependency update pull request titles to include a "[bump]" prefix for improved identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->