### PR TITLE
Configure Telegram API retries

### DIFF
--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -231,7 +231,7 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 			return response;
 		}
 
-		for (int retry = 1; retry <= 3 && response.parameters() != null && response.parameters().retryAfter() > 0; retry++) {
+		for (int retry = 1; retry <= 3 && response.parameters() != null && response.parameters().retryAfter() != null; retry++) {
 			var retryDelay = Duration.ofSeconds(response.parameters().retryAfter());
 			try {
 				Thread.sleep(retryDelay);

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -235,19 +235,19 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 
 		for (int retry = 1; retry <= 3 && isRetriable(response.parameters()); retry++) {
 			var retryDelay = response.parameters().retryAfter();
-			LOGGER.at(Level.WARN).log("The {} request failed, retrying in {} seconds", request.getMethod(), retryDelay);
+			LOGGER.at(Level.WARN).log("The {} request failed: retrying in {} seconds", request.getMethod(), retryDelay);
 
 			try {
 				Thread.sleep(Duration.ofSeconds(retryDelay));
-
-				response = bot.execute(request);
-
-				if (response.isOk()) {
-					return response;
-				}
 			} catch (InterruptedException _) {
 				Thread.currentThread().interrupt();
 				break;
+			}
+
+			response = bot.execute(request);
+
+			if (response.isOk()) {
+				return response;
 			}
 		}
 
@@ -255,7 +255,7 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 	}
 
 	private static boolean isRetriable(@Nullable ResponseParameters parameters) {
-		return parameters != null && parameters.retryAfter() != null && parameters.retryAfter() > 0;
+		return parameters != null && parameters.retryAfter() != null && parameters.retryAfter() >= 0;
 	}
 
 	private static void deleteTempFiles(Set<Path> pathsToDelete) {

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -231,23 +231,19 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 			return response;
 		}
 
-		waitFor(Duration.ofSeconds(15));
+		try {
+			Thread.sleep(Duration.ofSeconds(15));
 
-		response = bot.execute(request);
+			response = bot.execute(request);
 
-		if (response.isOk()) {
-			return response;
+			if (response.isOk()) {
+				return response;
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
 
 		throw new TelegramApiException(request.getMethod(), response.description());
-	}
-
-	private static void waitFor(Duration duration) {
-		try {
-			Thread.sleep(duration);
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		}
 	}
 
 	private static void deleteTempFiles(Set<Path> pathsToDelete) {

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -231,16 +231,20 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 			return response;
 		}
 
-		try {
-			Thread.sleep(Duration.ofSeconds(15));
+		if (response.parameters() != null && response.parameters().retryAfter() > 0) {
+			var retryDelay = Duration.ofSeconds(response.parameters().retryAfter());
 
-			response = bot.execute(request);
+			try {
+				Thread.sleep(retryDelay);
 
-			if (response.isOk()) {
-				return response;
+				response = bot.execute(request);
+
+				if (response.isOk()) {
+					return response;
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
 			}
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
 		}
 
 		throw new TelegramApiException(request.getMethod(), response.description());

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -23,6 +23,7 @@ import com.pengrad.telegrambot.ExceptionHandler;
 import com.pengrad.telegrambot.TelegramBot;
 import com.pengrad.telegrambot.TelegramException;
 import com.pengrad.telegrambot.UpdatesListener;
+import com.pengrad.telegrambot.model.ResponseParameters;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.model.request.ReplyParameters;
 import com.pengrad.telegrambot.model.request.richmessages.InputRichMessage;
@@ -33,6 +34,7 @@ import com.pengrad.telegrambot.request.SendDocument;
 import com.pengrad.telegrambot.request.richmessages.SendRichMessage;
 import com.pengrad.telegrambot.request.richmessages.SendRichMessageDraft;
 import com.pengrad.telegrambot.response.BaseResponse;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.event.Level;
 
 import java.io.File;
@@ -231,10 +233,12 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 			return response;
 		}
 
-		for (int retry = 1; retry <= 3 && response.parameters() != null && response.parameters().retryAfter() != null; retry++) {
-			var retryDelay = Duration.ofSeconds(response.parameters().retryAfter());
+		for (int retry = 1; retry <= 3 && isRetriable(response.parameters()); retry++) {
+			var retryDelay = response.parameters().retryAfter();
+			LOGGER.at(Level.WARN).log("The {} request failed, retrying in {} seconds", request.getMethod(), retryDelay);
+
 			try {
-				Thread.sleep(retryDelay);
+				Thread.sleep(Duration.ofSeconds(retryDelay));
 
 				response = bot.execute(request);
 
@@ -248,6 +252,10 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 		}
 
 		throw new TelegramApiException(request.getMethod(), response.description());
+	}
+
+	private static boolean isRetriable(@Nullable ResponseParameters parameters) {
+		return parameters != null && parameters.retryAfter() != null && parameters.retryAfter() > 0;
 	}
 
 	private static void deleteTempFiles(Set<Path> pathsToDelete) {

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -230,7 +231,23 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 			return response;
 		}
 
+		waitFor(Duration.ofSeconds(15));
+
+		response = bot.execute(request);
+
+		if (response.isOk()) {
+			return response;
+		}
+
 		throw new TelegramApiException(request.getMethod(), response.description());
+	}
+
+	private static void waitFor(Duration duration) {
+		try {
+			Thread.sleep(duration);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	private static void deleteTempFiles(Set<Path> pathsToDelete) {

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -231,21 +231,19 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 			return response;
 		}
 
-		if (response.parameters() != null && response.parameters().retryAfter() > 0) {
-			for (int retry = 1; retry <= 3; retry++) {
-				var retryDelay = Duration.ofSeconds(response.parameters().retryAfter());
-				try {
-					Thread.sleep(retryDelay);
+		for (int retry = 1; retry <= 3 && response.parameters() != null && response.parameters().retryAfter() > 0; retry++) {
+			var retryDelay = Duration.ofSeconds(response.parameters().retryAfter());
+			try {
+				Thread.sleep(retryDelay);
 
-					response = bot.execute(request);
+				response = bot.execute(request);
 
-					if (response.isOk()) {
-						return response;
-					}
-				} catch (InterruptedException _) {
-					Thread.currentThread().interrupt();
-					break;
+				if (response.isOk()) {
+					return response;
 				}
+			} catch (InterruptedException _) {
+				Thread.currentThread().interrupt();
+				break;
 			}
 		}
 

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -255,7 +255,7 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 	}
 
 	private static boolean isRetriable(@Nullable ResponseParameters parameters) {
-		return parameters != null && parameters.retryAfter() != null && parameters.retryAfter() >= 0;
+		return parameters != null && parameters.retryAfter() != null;
 	}
 
 	private static void deleteTempFiles(Set<Path> pathsToDelete) {

--- a/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
+++ b/src/main/java/com/github/stickerifier/stickerify/bot/Stickerify.java
@@ -232,18 +232,20 @@ public record Stickerify(TelegramBot bot, Executor executor) implements UpdatesL
 		}
 
 		if (response.parameters() != null && response.parameters().retryAfter() > 0) {
-			var retryDelay = Duration.ofSeconds(response.parameters().retryAfter());
+			for (int retry = 1; retry <= 3; retry++) {
+				var retryDelay = Duration.ofSeconds(response.parameters().retryAfter());
+				try {
+					Thread.sleep(retryDelay);
 
-			try {
-				Thread.sleep(retryDelay);
+					response = bot.execute(request);
 
-				response = bot.execute(request);
-
-				if (response.isOk()) {
-					return response;
+					if (response.isOk()) {
+						return response;
+					}
+				} catch (InterruptedException _) {
+					Thread.currentThread().interrupt();
+					break;
 				}
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
 			}
 		}
 

--- a/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/MockResponses.java
@@ -13,6 +13,17 @@ public final class MockResponses {
 			}
 			""").build();
 
+	static final MockResponse FAILURE_RESPONSE = new MockResponse.Builder().body("""
+			{
+				ok: false,
+				error_code: 429,
+				description: "Too Many Requests: retry after 3",
+				parameters: {
+					retry_after: 3
+				}
+			}
+			""").build();
+
 	static final MockResponse START_MESSAGE = new MockResponse.Builder().body("""
 			{
 				ok: true,

--- a/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
+++ b/src/test/java/com/github/stickerifier/stickerify/bot/StickerifyTest.java
@@ -404,4 +404,24 @@ class StickerifyTest {
 			assertResponseContainsMarkdownMessage(sendRichMessage, Answer.ERROR);
 		}
 	}
+
+	@Test
+	void retryApiCall() throws Exception {
+		server.enqueue(MockResponses.HELP_MESSAGE);
+		server.enqueue(MockResponses.FAILURE_RESPONSE);
+		server.enqueue(MockResponses.SUCCESS_RESPONSE);
+
+		try (var _ = runBot()) {
+			var getUpdates = server.takeRequest();
+			assertEquals("/api/token/getUpdates", getUpdates.getTarget());
+
+			var firstSendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", firstSendRichMessage.getTarget());
+
+			var secondSendRichMessage = server.takeRequest();
+			assertEquals("/api/token/sendRichMessage", secondSendRichMessage.getTarget());
+
+			assertResponseContainsMarkdownMessage(secondSendRichMessage, Answer.HELP);
+		}
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Telegram API interactions by retrying failed requests when the API provides a valid, non-negative `retry_after` delay (up to 3 attempts).
  * Retry attempts now pause for the indicated delay, and if interrupted, stop retrying and surface the final error details.
* **Tests**
  * Added coverage to confirm retry behavior by verifying that a successful follow-up message is sent after an initial rate-limit style failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->